### PR TITLE
feat(next): switched to tag based caching

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -3,7 +3,7 @@ import { QuestionLink } from './components/question-link';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 import { getSentences } from '@/app/(site)/util/get-sentences';
 
-export const revalidate = 300;
+export const revalidate = 18000; // 5h
 
 export default async function Home() {
 	const queryClient = new QueryClient();

--- a/src/app/(site)/talks/[slug]/page.tsx
+++ b/src/app/(site)/talks/[slug]/page.tsx
@@ -3,8 +3,6 @@ import { FileList, FileRowLink } from '@/components/file-display';
 import { File } from 'lucide-react';
 import { NotTheFilesYouReLookingFor } from '@/components/file-display';
 
-export const revalidate = 300;
-
 const Page = async ({ params }: { params: { slug: string } }) => {
 	const res = await getTalkData(params.slug);
 

--- a/src/app/(site)/talks/page.tsx
+++ b/src/app/(site)/talks/page.tsx
@@ -13,8 +13,6 @@ import { Fragment } from 'react';
 import { CustomPortableText } from '@/components/custom-portable-text';
 import { TimeAgo } from '@/components/time-ago/time-ago';
 
-export const revalidate = 300;
-
 const Page = async () => {
 	const [talks, content, events] = await Promise.all([
 		getPublicTalks(),

--- a/src/app/(site)/util/get-sentences.ts
+++ b/src/app/(site)/util/get-sentences.ts
@@ -1,4 +1,3 @@
-import { getGeneralInfo } from '@/lib/sanity/get-general-info';
 import { prepareTypeAnimationArray } from '@/lib/prepare-type-animation-array';
 import { getIntroSentencesV2 } from '@/lib/sanity/get-intro-sentences-v2';
 

--- a/src/app/(site)/wiki/[slug]/layout.tsx
+++ b/src/app/(site)/wiki/[slug]/layout.tsx
@@ -5,8 +5,6 @@ import { File } from 'lucide-react';
 import { getWikiContent } from '@/lib/sanity/get-wiki-content';
 import { getGeneralInfo } from '@/lib/sanity/get-general-info';
 
-export const revalidate = 300;
-
 export default async function Layout({ children }: { children: ReactNode }) {
 	const [content, info] = await Promise.all([getWikiContent(), getGeneralInfo()]);
 

--- a/src/app/(site)/wiki/[slug]/page.tsx
+++ b/src/app/(site)/wiki/[slug]/page.tsx
@@ -3,8 +3,6 @@ import { getWikiPageContent } from '@/lib/sanity/get-wiki-content';
 import { FileContent } from '@/components/file-display';
 import { CustomPortableText } from '@/components/custom-portable-text';
 
-export const revalidate = 300;
-
 const Page = async ({ params }: { params: { slug: string } }) => {
 	const res = await getWikiPageContent(params.slug);
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,39 @@
+import { revalidateTag } from 'next/cache';
+import { type NextRequest, NextResponse } from 'next/server';
+import { parseBody } from 'next-sanity/webhook';
+
+type WebhookPayload = {
+	_type: string;
+};
+
+export async function POST(req: NextRequest) {
+	try {
+		const { isValidSignature, body } = await parseBody<WebhookPayload>(
+			req,
+			process.env.SANITY_REVALIDATE_SECRET,
+		);
+
+		if (!isValidSignature) {
+			const message = 'Invalid signature';
+			return new Response(JSON.stringify({ message, isValidSignature, body }), {
+				status: 401,
+			});
+		}
+
+		if (!body?._type) {
+			const message = 'Bad Request';
+			return new Response(JSON.stringify({ message, body }), { status: 400 });
+		}
+
+		revalidateTag(body._type);
+
+		console.log('Successfully revalidated');
+
+		return NextResponse.json({ body });
+	} catch (err) {
+		console.error(err);
+		const message =
+			err instanceof Error && 'message' in err ? err.message : (err as string);
+		return new Response(message, { status: 500 });
+	}
+}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
 
 		revalidateTag(body._type);
 
-		console.log('Successfully revalidated');
+		console.log('Successfully revalidated tag:', body._type);
 
 		return NextResponse.json({ body });
 	} catch (err) {

--- a/src/lib/sanity-client.ts
+++ b/src/lib/sanity-client.ts
@@ -1,5 +1,4 @@
-import { createClient } from 'next-sanity';
-import { cache } from 'react';
+import { createClient, QueryParams } from 'next-sanity';
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!;
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!;
@@ -14,7 +13,18 @@ export const getClient = (useCdn: boolean) =>
 	});
 
 const client = getClient(false);
-const cdnClient = getClient(true);
 
-export const cachedClientFetch = cache(client.fetch.bind(client));
-export const cachedCdnClientFetch = cache(cdnClient.fetch.bind(cdnClient));
+type SanityFetchParameters = {
+	query: string;
+	params?: QueryParams;
+	tags?: string[];
+};
+
+export const sanityFetch = async <QueryResponse>({
+	query,
+	params = {},
+	tags,
+}: SanityFetchParameters) =>
+	client.fetch<QueryResponse>(query, params, {
+		next: { tags },
+	});

--- a/src/lib/sanity/get-events.ts
+++ b/src/lib/sanity/get-events.ts
@@ -1,5 +1,4 @@
-import { cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 import { PortableTextProps } from '@portabletext/react';
 
 export type EventType = {
@@ -8,8 +7,8 @@ export type EventType = {
 	url: string;
 };
 
-export const getEvents = () => {
-	return cachedClientFetch<EventType[]>(
-		groq`*[_type == 'event'] | order(order asc) { name, description, url }`,
-	);
-};
+export const getEvents = () =>
+	sanityFetch<EventType[]>({
+		query: `*[_type == 'event'] | order(order asc) { name, description, url }`,
+		tags: ['event'],
+	});

--- a/src/lib/sanity/get-general-info.ts
+++ b/src/lib/sanity/get-general-info.ts
@@ -1,5 +1,4 @@
-import { cachedCdnClientFetch, cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 
 export type GeneralInfoType = {
 	name: string;
@@ -7,7 +6,8 @@ export type GeneralInfoType = {
 	fileUrl: string;
 };
 
-export const getGeneralInfo = (useCdn = false): Promise<GeneralInfoType> =>
-	(useCdn ? cachedClientFetch : cachedCdnClientFetch)(
-		groq`*[_type == 'general'][0]{ name, introSentences, "fileUrl": cv.asset->url }`,
-	);
+export const getGeneralInfo = () =>
+	sanityFetch<GeneralInfoType>({
+		query: `*[_type == 'general'][0]{ name, introSentences, "fileUrl": cv.asset->url }`,
+		tags: ['general'],
+	});

--- a/src/lib/sanity/get-intro-sentences-v2.ts
+++ b/src/lib/sanity/get-intro-sentences-v2.ts
@@ -1,5 +1,4 @@
-import { cachedCdnClientFetch, cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 
 export type IntroSentenceV2 = {
 	sentence: string;
@@ -10,7 +9,8 @@ export type IntroSentencesV2Type = {
 	introSentencesV2: IntroSentenceV2[];
 };
 
-export const getIntroSentencesV2 = (useCdn = false): Promise<IntroSentencesV2Type> =>
-	(useCdn ? cachedClientFetch : cachedCdnClientFetch)(
-		groq`*[_type == 'general'][0]{ introSentencesV2 }`,
-	);
+export const getIntroSentencesV2 = (useCdn = false) =>
+	sanityFetch<IntroSentencesV2Type>({
+		query: `*[_type == 'general'][0]{ introSentencesV2 }`,
+		tags: ['general'],
+	});

--- a/src/lib/sanity/get-public-talks.ts
+++ b/src/lib/sanity/get-public-talks.ts
@@ -1,5 +1,4 @@
-import { cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 
 export type PublicTalk = {
 	event: string;
@@ -8,13 +7,16 @@ export type PublicTalk = {
 	slug: string;
 };
 
-export const getPublicTalks = () => {
-	return cachedClientFetch<PublicTalk[]>(groq`
+const query = `
 *[_type == 'talk' && public == true]{
 	"event": eventV2 -> name,
 	talk,
 	date,
 	slug,
-}
-`);
-};
+}`;
+
+export const getPublicTalks = () =>
+	sanityFetch<PublicTalk[]>({
+		query,
+		tags: ['talk'],
+	});

--- a/src/lib/sanity/get-talk-data.ts
+++ b/src/lib/sanity/get-talk-data.ts
@@ -1,5 +1,4 @@
-import { cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 
 export type TalkFile = {
 	filename: string;
@@ -15,9 +14,7 @@ export type TalkData = {
 	files: TalkFile[];
 };
 
-export const getTalkData = (slug: string) => {
-	return cachedClientFetch<TalkData | null>(
-		groq`
+const query = `
 *[_type == 'talk' && slug == $slug][0]{
 	event,
 	talk,
@@ -28,7 +25,11 @@ export const getTalkData = (slug: string) => {
     "url": coalesce(file.asset->url, url)
   },
 	date
-}`,
-		{ slug },
-	);
-};
+}`;
+
+export const getTalkData = (slug: string) =>
+	sanityFetch<TalkData | null>({
+		query,
+		params: { slug },
+		tags: ['talk'],
+	});

--- a/src/lib/sanity/get-talks-section-content.ts
+++ b/src/lib/sanity/get-talks-section-content.ts
@@ -1,13 +1,12 @@
-import { cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 import { PortableTextProps } from '@portabletext/react';
 
 export type TalksSectionContent = {
 	talksContent: PortableTextProps['value'];
 };
 
-export const getTalksSectionContent = async () => {
-	return cachedClientFetch<TalksSectionContent | null>(
-		groq`*[_type == 'general'][0]{ talksContent }`,
-	);
-};
+export const getTalksSectionContent = () =>
+	sanityFetch<TalksSectionContent | null>({
+		query: `*[_type == 'general'][0]{ talksContent }`,
+		tags: ['general'],
+	});

--- a/src/lib/sanity/get-wiki-content.ts
+++ b/src/lib/sanity/get-wiki-content.ts
@@ -1,5 +1,4 @@
-import { cachedClientFetch } from '@/lib/sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '@/lib/sanity-client';
 import { PortableTextProps } from '@portabletext/react';
 
 export type WikiContent = {
@@ -8,10 +7,11 @@ export type WikiContent = {
 	relativeTimeAgo: string;
 };
 
-export const getWikiContent = async () => {
-	return cachedClientFetch<WikiContent[]>(
-		groq`*[_type == 'wiki-page'] | order(order asc) { filename, commitMsg, relativeTimeAgo }`,
-	);
+export const getWikiContent = () => {
+	return sanityFetch<WikiContent[]>({
+		query: `*[_type == 'wiki-page'] | order(order asc) { filename, commitMsg, relativeTimeAgo }`,
+		tags: ['wiki-page'],
+	});
 };
 
 export type WikiPageContent = {
@@ -21,7 +21,8 @@ export type WikiPageContent = {
 };
 
 export const getWikiPageContent = async (docName: string) => {
-	return cachedClientFetch<WikiPageContent | null>(
-		groq`*[_type == 'wiki-page' && filename == $docName][0]{ content, filename, commitMsg }`, { docName }
-	);
+	return sanityFetch<WikiPageContent | null>({
+		query: `*[_type == 'wiki-page' && filename == $docName][0]{ content, filename, commitMsg }`,
+		params: { docName },
+	});
 };

--- a/src/lib/server-only/llm-context-utils.ts
+++ b/src/lib/server-only/llm-context-utils.ts
@@ -1,12 +1,12 @@
-import { cachedClientFetch } from '../sanity-client';
-import { groq } from 'next-sanity';
+import { sanityFetch } from '../sanity-client';
 import { OpenAI } from 'openai';
 import 'server-only';
 
 export const getLlmContext = async () => {
-	return cachedClientFetch<{ text: string; order: number }[]>(
-		groq`*[_type == 'llm-content'] | order(order asc)`,
-	);
+	return sanityFetch<{ text: string; order: number }[]>({
+		query: `*[_type == 'llm-content'] | order(order asc)`,
+		tags: ['llm-content'],
+	});
 };
 
 export const extractEdgeAnswer = async ({ choices }: OpenAI.ChatCompletion) => {


### PR DESCRIPTION
This PR enables sanity's tag based chaching feature, where the sanity client now fully supports tag based fetching. This enables me to add a webhook to directly invalidate the cache whenever I change some content in the CMS.